### PR TITLE
v2: ./start.shのヒントを読み込み直後に表示

### DIFF
--- a/src/v2/terminal/app.ts
+++ b/src/v2/terminal/app.ts
@@ -249,5 +249,7 @@ modeButtons.forEach((button) => {
 })
 
 updatePrompt()
-resetHintTimer()
+// Show the ./start.sh hint right away instead of waiting for the first
+// idle timeout — a first-time visitor shouldn't have to guess or wait.
+printRaw(HINT_TEXT, 'pf-line-hint')
 input.focus()


### PR DESCRIPTION
## Summary
- v1ヘッダーの「v2」ボタンから`/v2`に来た直後、これまでは6秒間操作がないと`./start.sh`のヒントが出なかった。読み込み直後に即座に表示するようにした。

## Test plan
- [x] `npm run build` が通ることを確認
- [x] ESLint / Prettier を通過
- [x] Playwrightでページ読み込み直後に `Hint: try ./start.sh` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op)_