### PR TITLE
v2: プレビューパネルの閉じるボタンとアクセシビリティ改善

### DIFF
--- a/src/pages/v2/index.astro
+++ b/src/pages/v2/index.astro
@@ -38,7 +38,7 @@ import { hobbies, profile, projects, research, skills } from '@/v2/data/portfoli
 			<section id='pf-terminal-view' class='pf-view'>
 				<div class='pf-terminal-layout'>
 					<div class='pf-window' id='pf-window'>
-						<div class='pf-window__titlebar'>
+						<div class='pf-window__titlebar' aria-hidden='true'>
 							<span class='pf-dot pf-dot--red'></span>
 							<span class='pf-dot pf-dot--yellow'></span>
 							<span class='pf-dot pf-dot--green'></span>

--- a/src/v2/styles/terminal.css
+++ b/src/v2/styles/terminal.css
@@ -336,10 +336,28 @@ button.pf-chip:hover {
 	gap: 8px;
 }
 
+.pf-preview__header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 8px;
+}
+
 .pf-preview h3 {
 	color: var(--pf-green);
 	font-size: 16px;
 	margin: 0;
+}
+
+.pf-preview__close {
+	/* Square icon button reusing the sm touch step as its side length,
+	   instead of the pill's horizontal padding — a "×" needs a square hit
+	   area, not a wide pill. */
+	flex-shrink: 0;
+	width: var(--pf-touch-sm);
+	padding: 0;
+	font-size: 14px;
+	line-height: 1;
 }
 
 .pf-preview p {

--- a/src/v2/terminal/app.ts
+++ b/src/v2/terminal/app.ts
@@ -116,8 +116,20 @@ function renderPreview(slug: string) {
 	preview.hidden = false
 	preview.innerHTML = ''
 
+	const header = document.createElement('div')
+	header.className = 'pf-preview__header'
 	const h3 = document.createElement('h3')
 	h3.textContent = project.heading
+	const closeButton = document.createElement('button')
+	closeButton.type = 'button'
+	closeButton.className = 'pf-chip pf-chip--sm pf-preview__close'
+	closeButton.setAttribute('aria-label', 'Close preview')
+	closeButton.textContent = '×'
+	closeButton.addEventListener('click', () => {
+		preview.hidden = true
+	})
+	header.append(h3, closeButton)
+
 	const p = document.createElement('p')
 	p.textContent = project.concept
 	const tech = document.createElement('div')
@@ -128,7 +140,7 @@ function renderPreview(slug: string) {
 		span.textContent = t
 		tech.appendChild(span)
 	})
-	preview.append(h3, p, tech)
+	preview.append(header, p, tech)
 
 	if (project.href) {
 		const a = document.createElement('a')

--- a/src/v2/terminal/engine.ts
+++ b/src/v2/terminal/engine.ts
@@ -61,7 +61,7 @@ export class TerminalEngine {
 		}
 
 		const [cmd, ...rest] = tokens
-		const partial = hasTrailingSpace ? '' : rest.pop() ?? ''
+		const partial = hasTrailingSpace ? '' : (rest.pop() ?? '')
 		const base = rest.join(' ')
 
 		let candidates: string[] = []


### PR DESCRIPTION
## Summary
開発サイクルの一環で、v2のコードレビューから見つけた2点を修正。

- `open`コマンドで開くプレビューパネルに閉じる手段がなく、モードを切り替えるかリロードしないと消せなかった。既存のChipアトムを再利用した正方形の閉じるボタン(×)を追加。
- ターミナルウィンドウのタイトルバー(赤/黄/緑の信号ドット)は装飾のみでスクリーンリーダーに読み上げる意味がないため、`aria-hidden="true"`を付けた。

## Test plan
- [x] `npm run test`(vitest, 37件)が通ることを確認
- [x] `npm run build`(型チェック含む)が通ることを確認
- [x] ESLint / Prettier を通過
- [x] Playwrightで閉じるボタンをクリックしてプレビューパネルが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op)_