### PR TITLE
v1: ヘッダーのv2切替をLucideアイコンに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-08 (4)
+
+- improve: v1ヘッダーのv2切替リンクを、テキスト「v2」からLucideの`square-terminal`アイコンに変更。`src/icons/square-terminal.svg`をastro-iconのローカルアイコンとして追加し、`currentColor`でダーク/ライト両テーマに追従する。アクセシブルな名前は`sr-only`テキストとtitle属性で維持。
+
 ## 2026-09-08 (3)
 
 - improve: start.shのブート完了メッセージを、単なるローディング演出から「ポートフォリオ=探索できるファイルシステム」というコンセプトが伝わる内容に変更。`whoami · ls · cd projects · open <slug> · help`という具体的な例コマンドを最初から提示するようにした。

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from 'astro-icon/components'
 import IconButton from '@/components/IconButton.astro'
 ---
 
@@ -31,7 +32,10 @@ import IconButton from '@/components/IconButton.astro'
 		*/
 			}
 
-			<IconButton as='a' href='/v2' title='ターミナル版ポートフォリオを試す'>v2</IconButton>
+			<IconButton as='a' href='/v2' title='ターミナル版ポートフォリオを試す'>
+				<span class='sr-only'>ターミナル版ポートフォリオ</span>
+				<Icon name='square-terminal' class='h-[1.2rem] w-[1.2rem]' />
+			</IconButton>
 
 			<IconButton id='toggleDarkMode'>
 				<span class='sr-only'>Dark Theme</span>

--- a/src/icons/square-terminal.svg
+++ b/src/icons/square-terminal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 11 2-2-2-2"/><path d="M11 13h4"/><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/></svg>


### PR DESCRIPTION
## Summary
- v1ヘッダーの「v2」切替リンクをテキストラベルからLucideの`square-terminal`アイコンに変更。隣のダークモード切替(アイコンのみ)との見た目の統一感を出した。
- `src/icons/square-terminal.svg`をastro-iconのローカルアイコンとして追加。`stroke="currentColor"`でダーク/ライト両テーマに自動追従する。
- アクセシブルな名前は`sr-only`テキスト(「ターミナル版ポートフォリオ」)と既存の`title`属性で維持。

## Test plan
- [x] `npm run test`(vitest, 37件)が通ることを確認
- [x] `npm run build`が通ることを確認
- [x] ESLint / Prettier を通過
- [x] Playwrightでライト/ダーク両モードでアイコンが表示され、`currentColor`で色が切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op)_