### PR TITLE
fix: v2ヘッダーのEN/v1チップの右上固定

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-09-10
+
+- fix: v2ヘッダーの`v1`/`EN`/`terminal`チップ群が、狭い画面で`.pf-header`が折り返した際に左寄せになり「右上」から外れていた。`.pf-header__actions`に`margin-left: auto`を追加し、折り返し後の自分の行でも右端に固定されるようにした。
+
 ## 2026-09-09 (3)
 
 - feat: v2ターミナルに基本コマンド`pwd`/`echo <text>`/`date`を追加。`help`とTab補完の一覧にも反映し、READMEのコマンド表も更新した(テスト4件追加、計51件)。

--- a/src/v2/styles/terminal.css
+++ b/src/v2/styles/terminal.css
@@ -47,6 +47,11 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	/* Stays pinned to the top-right even once `.pf-header` wraps it onto its
+	   own line on narrow screens — without this it falls back to flex-start
+	   (left) because a lone item on a wrapped line has nothing to space
+	   against. */
+	margin-left: auto;
 }
 
 /* One pill atom for the whole page (docs/DESIGN.md): nav links, the mode


### PR DESCRIPTION
## Summary
- v2ヘッダーの`v1`/`EN`/`terminal`チップ群は、`.pf-header`がwrapする狭い画面幅では自分の行で左寄せになり、意図していた「右上固定」から外れていた(390px幅で実機確認済み)。
- `.pf-header__actions`に`margin-left: auto`を追加し、折り返した後の行でも右端に固定されるようにした。

## Test plan
- [x] `npm run test` — 51件全て通過
- [x] `npm run build` — 成功
- [x] 実ブラウザ(Playwright)で1280px(デスクトップ)・390px(モバイル)の両方をスクリーンショットで確認。修正前はモバイル幅でチップ群が左寄せの別行になっていたが、修正後は右上に固定されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7R7nH6G6RY4Dua7vF59op)_